### PR TITLE
Fix for require function

### DIFF
--- a/source/luaPlayer.cpp
+++ b/source/luaPlayer.cpp
@@ -81,6 +81,8 @@ const char *runScript(const char* script, bool isStringBuffer)
 	int s = 0;
 	const char *errMsg = NULL;
 	
+	luaL_dostring(L, "package.path = 'app0:/?.lua'");
+	
 	if(!isStringBuffer) 
 		s = luaL_loadfile(L, script);
 	else 


### PR DESCRIPTION
This fixes the crash when calling 'require'. But, to work, vita-luajit must be compiled without vita-libdl support too.

In luajit's source, change line 110 of lj_arch.h from 
`#define LJ_TARGET_DLOPEN	(LJ_TARGET_POSIX || LJ_TARGET_PSP2)` 
to
`#define LJ_TARGET_DLOPEN	(LJ_TARGET_POSIX)`

with this modification, we'll lose FFI support, but 'require' will work with *.lua files.