### PR TITLE
Update to LuaJIT 2.1/ Fix `require` and most likely `module`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 TARGET		:= lpp-vita
 SOURCES		:= source/include/ftp source/include source source/include/audiodec
 			
-INCLUDES	:= include
+INCLUDES	:= include $VITASDK/arm-vita-eabi/include/luajit-2.1
 
 LIBS = -lcurl -lssl -lcrypto -lvorbisfile -lvorbis -logg -lsndfile -lvita2d -lSceLibKernel_stub -lScePvf_stub \
 	-limgui_vita2d -lSceJpegEnc_stub -lSceAppMgr_stub -lSceCtrl_stub -lSceTouch_stub -lSceMotion_stub \
 	-lScePromoterUtil_stub -lm -lSceNet_stub -lSceNetCtl_stub -lSceAppUtil_stub -lScePgf_stub \
 	-ljpeg -lfreetype -lc -lScePower_stub -lSceCommonDialog_stub -lpng16 -lz -lSceCamera_stub \
 	-lspeexdsp -lmpg123 -lSceAudio_stub -lSceGxm_stub -lSceDisplay_stub -lSceShellSvc_stub -limagequant \
-	-lopusfile -lopus -lSceHttp_stub -lSceAudioIn_stub -lluajit -ldl -ltaihen_stub  -lSceSysmodule_stub \
-	-lSceShutterSound_stub -lSceSsl_stub -lSceVshBridge_stub -lSceAvPlayer_stub -lSceRegistryMgr_stub
+	-lopusfile -lFLAC -lvorbis -lvorbisenc -lopus -lSceHttp_stub -lSceAudioIn_stub -lluajit-5.1 -ldl \ 
+	-ltaihen_stub -lSceKernelModulemgr_stub -lSceSblSsMgr_stub  -lSceSysmodule_stub -lSceShutterSound_stub \
+	-lSceSsl_stub -lSceVshBridge_stub -lSceAvPlayer_stub -lSceRegistryMgr_stub
 
 CFILES   := $(foreach dir,$(SOURCES), $(wildcard $(dir)/*.c))
 CPPFILES   := $(foreach dir,$(SOURCES), $(wildcard $(dir)/*.cpp))

--- a/source/luaPlayer.cpp
+++ b/source/luaPlayer.cpp
@@ -41,20 +41,6 @@ static lua_State *L;
 
 char errorMex[1024];
 
-// lua-compat
-void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
-  luaL_checkstack(L, nup+1, "too many upvalues");
-  for (; l->name != NULL; l++) {  /* fill the table with given functions */
-    int i;
-    lua_pushstring(L, l->name);
-    for (i = 0; i < nup; i++)  /* copy upvalues to the top */
-      lua_pushvalue(L, -(nup + 1));
-    lua_pushcclosure(L, l->func, nup);  /* closure with those upvalues */
-    lua_settable(L, -(nup + 3)); /* table must be below the upvalues, the name and the closure */
-  }
-  lua_pop(L, nup);  /* remove upvalues */
-}
-
 const char *runScript(const char* script, bool isStringBuffer)
 {
 	L = luaL_newstate();


### PR DESCRIPTION
Should add proper FFI support and removes need for lua-compat function.