### PR TITLE
Fix utils.h and lbz2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LIBS = -lcurl -lssl -lcrypto -lvorbisfile -lvorbis -logg -lsndfile -lvita2d -lSc
 	-lspeexdsp -lmpg123 -lSceAudio_stub -lSceGxm_stub -lSceDisplay_stub -lSceShellSvc_stub -limagequant \
 	-lopusfile -lFLAC -lvorbis -lvorbisenc -lopus -lSceHttp_stub -lSceAudioIn_stub -lluajit-5.1 -ldl \
 	-ltaihen_stub -lSceKernelModulemgr_stub -lSceSblSsMgr_stub  -lSceSysmodule_stub -lSceShutterSound_stub \
-	-lSceSsl_stub -lSceVshBridge_stub -lSceAvPlayer_stub -lSceRegistryMgr_stub
+	-lSceSsl_stub -lSceVshBridge_stub -lSceAvPlayer_stub -lSceRegistryMgr_stub -lbz2
 
 CFILES   := $(foreach dir,$(SOURCES), $(wildcard $(dir)/*.c))
 CPPFILES   := $(foreach dir,$(SOURCES), $(wildcard $(dir)/*.cpp))

--- a/source/include/utils.h
+++ b/source/include/utils.h
@@ -1,4 +1,10 @@
+// Misc utils
+#define ALIGN(x, a)	(((x) + ((a) - 1)) & ~((a) - 1))
 
 // ASCII / UTF16 compatibility
 void utf2ascii(char* dst, uint16_t* src);
 void ascii2utf(uint16_t* dst, char* src);
+
+// GPU utils
+void *gpu_alloc(SceKernelMemBlockType type, unsigned int size, unsigned int alignment, unsigned int attribs, SceUID *uid);
+void gpu_free(SceUID uid);

--- a/source/luaGraphics.cpp
+++ b/source/luaGraphics.cpp
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <vitasdk.h>
 #include <vita2d.h>
-#include <utils.h>
+#include "include/utils.h"
 #include "include/luaplayer.h"
 
 extern "C"{

--- a/source/luaNetwork.cpp
+++ b/source/luaNetwork.cpp
@@ -30,6 +30,7 @@
 #define NET_INIT_SIZE 1*1024*1024
 #include <vitasdk.h>
 #include <curl/curl.h>
+#include <cstring>
 #include "include/luaplayer.h"
 
 extern "C"{

--- a/source/luaRender.cpp
+++ b/source/luaRender.cpp
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <vitasdk.h>
 extern "C"{
-	#include <utils.h> // utils.h file from vita2d
+	#include "include/utils.h"
 }
 #include <vita2d.h>
 #include "include/luaplayer.h"

--- a/source/luaVideo.cpp
+++ b/source/luaVideo.cpp
@@ -28,7 +28,7 @@
 #include <unistd.h>
 #include <vitasdk.h>
 extern "C"{
-#include <utils.h> // utils.h file from vita2d
+#include "include/utils.h"
 }
 #include "include/luaplayer.h"
 


### PR DESCRIPTION
Adds support for plain VitaSDK installation and fix BZ2. utils.h is not recognized by VitaSDK on a plain install.

utils.h uses defines from vita2d.