### PR TITLE
Fix: Security: OOB Read in Cloned Code

### DIFF
--- a/source/include/gifdec.c
+++ b/source/include/gifdec.c
@@ -381,7 +381,7 @@ read_image_data(gd_GIF *gif, int interlace)
             if (interlace)
                 y = interlaced_line_index((int) gif->fh, y);
             gif->frame[(gif->fy + y) * gif->width + gif->fx + x] = entry.suffix;
-            if (entry.prefix == 0xFFF)
+            if (entry.prefix == 0xFFF || entry.prefix >= table->nentries)
                 break;
             else
                 entry = table->entries[entry.prefix];


### PR DESCRIPTION
This PR fixes a potential security vulnerability in read_image_data() that was cloned from https://github.com/lecram/gifdec but did not receive the security patch.

### Details:
Affected Function: read_image_data() in source/include/gifdec.c
Original Fix: https://github.com/lecram/gifdec/commit/970558212348b60359f967a5d999078b6f9efe04

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/lecram/gifdec/commit/970558212348b60359f967a5d999078b6f9efe04
- https://nvd.nist.gov/vuln/detail/CVE-2022-43359

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
